### PR TITLE
Added a retry that uses user-agent header to the get function in get.py

### DIFF
--- a/storytracker/get.py
+++ b/storytracker/get.py
@@ -4,13 +4,20 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-def get(url, verify=True):
+def get(url, verify=True, user_agent="PhantomJS"):
     """
     Retrieves HTML from the provided URL.
     """
     # Request the URL
     logger.debug("Requesting %s" % url)
     response = requests.get(url)
+
+    # If the reqest returns a 4XX or 5XX response, try again with a user agent
+    if not response.status_code == requests.codes.ok:
+        logger.debug("Request returned a %d error, trying again with %s user-agent" % (response.status_code, user_agent))
+        response = requests.get(url, headers={'User-Agent': user_agent})
+        logger.debug("Second Request returned a %d" % response.status_code)
+
     html = response.text
     # Verify that the response is in fact HTML (but option to skip test)
     if verify and 'html' not in response.headers['content-type']:


### PR DESCRIPTION
_Background_
After running storytracker on a website that spat a 403 error at me, I decided to do a little research. A [few](http://wpengine.com/2014/01/06/staying-one-step-ahead/) [posts](http://webmasters.stackexchange.com/questions/35642/interpretation-of-empty-user-agent)/[articles](http://johannburkard.de/blog/www/spam/The-top-10-spam-bot-user-agents-you-MUST-block-NOW.html) are floating around recommending that servers should stop requests from empty user agents to stop bots. It seems like the big boys like LATimes, NYTimes and CNN recognize this isn't a good server protection strategy since apparently Facebook didn't use a user agent for a while. But WPEngine, a popular WordPress host, apparently blocks empty user agents.

_Problem_
The Python Request library by default passes a `None` user-agent in the header. Some servers send back 403 response statuses, forbidding access to the website. This will mean that an automated HTML archive might fill up with small HTML files that merely say "403 - Forbidden."

_Solution provided by this pull request_
If the first empty user-agent request returns a 4xx or 5xx error, retry using PhantomJS user-agent. Also, send a couple of debug logs to the user letting them know what the first request status code was, then what the second one was.

_Questions_
- Should this only catch 403 errors or all of the errors that aren't under the umbrella of `requests.codes.ok`? You might not want to retry 404 errors... but then again, a simple double check retry wouldn't be extremely harmful.
- Should the calls to the `get` method `browser_driver` to the user-agent header--are these always valid user agents? 
- If a second 4xx or 5xx is encountered, should an exception be thrown?
